### PR TITLE
Reduce number of deployment approvals

### DIFF
--- a/.github/workflows/DeployDevelop.yml
+++ b/.github/workflows/DeployDevelop.yml
@@ -53,7 +53,6 @@ jobs:
   package:
     name: Create packages
     runs-on: ubuntu-latest
-    environment: TEST
     needs: [ build-and-test ]
 
     steps:
@@ -81,7 +80,6 @@ jobs:
   deploy:
     name: Push packages to feed
     runs-on: ubuntu-latest
-    environment: TEST
     needs: [ package ]
     permissions:
       packages: write

--- a/.github/workflows/DeployMaster.yml
+++ b/.github/workflows/DeployMaster.yml
@@ -50,7 +50,6 @@ jobs:
   package:
     name: Create packages
     runs-on: ubuntu-latest
-    environment: PROD
     needs: [ build-and-test ]
 
     steps:
@@ -78,7 +77,6 @@ jobs:
   deploy:
     name: Push packages to feed
     runs-on: ubuntu-latest
-    environment: PROD
     needs: [ package ]
     permissions:
       packages: write
@@ -98,7 +96,6 @@ jobs:
   create-tag:
     name: Tag commit with version number
     runs-on: ubuntu-latest
-    environment: PROD
     needs: [ deploy ]
     permissions:
       contents: write


### PR DESCRIPTION
We only need approval on the first step, as all the steps are working with the same environment.
Because they depend on one another, it's ensured that without approval nothing will be pushed to feed.

Work on #8 